### PR TITLE
Towards ban/unban rework

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/jsdom": "^16.2.11",
     "@types/mocha": "^9.0.0",
     "@types/nedb": "^1.8.12",
-    "@types/node": "^16.7.10",
+    "@types/node": "^16.18.11",
     "@types/pg": "^8.6.5",
     "@types/request": "^2.48.8",
     "@types/shell-quote": "1.7.1",
@@ -40,7 +40,7 @@
     "mocha": "^9.0.1",
     "ts-mocha": "^9.0.2",
     "tslint": "^6.1.3",
-    "typescript": "^4.8.4",
+    "typescript": "^4.9.4",
     "typescript-formatter": "^7.2"
   },
   "dependencies": {

--- a/src/appservice/bot/ListCommand.tsx
+++ b/src/appservice/bot/ListCommand.tsx
@@ -79,7 +79,7 @@ const restart = defineInterfaceCommand<AppserviceBaseExecutor>({
             acceptor: findPresentationType("UserID"),
         }
     ]),
-    command: async(context, mjolnirId: UserID): Promise<CommandResult<true>> => {
+    command: async(context, _keywords, mjolnirId: UserID): Promise<CommandResult<true>> => {
         const mjolnirManager = context.appservice.mjolnirManager;
         const mjolnir = mjolnirManager.findUnstartedMjolnir(mjolnirId.localpart);
         if (mjolnir?.mjolnirRecord === undefined) {

--- a/src/commands/interface-manager/DeadDocumentHtml.ts
+++ b/src/commands/interface-manager/DeadDocumentHtml.ts
@@ -3,6 +3,7 @@
  * All rights reserved.
  */
 
+import { htmlEscape } from "../../utils";
 import { FringeLeafRenderFunction, FringeType, LeafNode, NodeTag, SimpleFringeRenderer } from "./DeadDocument";
 import { blank, staticString, TransactionalOutputContext } from "./DeadDocumentMarkdown";
 
@@ -12,7 +13,7 @@ HTML_RENDERER.registerRenderer<FringeLeafRenderFunction<TransactionalOutputConte
     FringeType.Leaf,
     NodeTag.TextNode,
     function (_tag: NodeTag, node: LeafNode, context: TransactionalOutputContext) {
-        context.output.writeString(node.data);
+        context.output.writeString(htmlEscape(node.data));
     }
 ).registerInnerNode(NodeTag.Emphasis,
     staticString('<em>'),

--- a/src/commands/interface-manager/InterfaceCommand.ts
+++ b/src/commands/interface-manager/InterfaceCommand.ts
@@ -102,18 +102,18 @@ export class CommandTable<ExecutorType extends BaseFunction> {
     }
 }
 
-const COMMAND_TABLE_TABLE = new Map<string, CommandTable<BaseFunction>>();
-export function defineCommandTable(name: string) {
+const COMMAND_TABLE_TABLE = new Map<string|symbol, CommandTable<BaseFunction>>();
+export function defineCommandTable(name: string|symbol) {
     if (COMMAND_TABLE_TABLE.has(name)) {
-        throw new TypeError(`A table called ${name} already exists`);
+        throw new TypeError(`A table called ${name.toString()} already exists`);
     }
     COMMAND_TABLE_TABLE.set(name, new CommandTable());
 }
 
-export function findCommandTable<ExecutorType extends BaseFunction>(name: string): CommandTable<ExecutorType> {
+export function findCommandTable<ExecutorType extends BaseFunction>(name: string|symbol): CommandTable<ExecutorType> {
     const entry = COMMAND_TABLE_TABLE.get(name);
     if (!entry) {
-        throw new TypeError(`Couldn't find a table called ${name}`);
+        throw new TypeError(`Couldn't find a table called ${name.toString()}`);
     }
     return entry as CommandTable<ExecutorType>;
 }
@@ -151,9 +151,15 @@ export class InterfaceCommand<ExecutorType extends BaseFunction> {
     }
 }
 
+// Shouldn't there be a callback interface.
+// imagine the old ban or sync command, each time you check a room
+// you add a callback to say when a user has been banned or a room
+// has been cleared or there was an error applying a ban to that room.
+// There could be a description in defineInterfaceComomand
+// for what each callback is and does for the adaptors to hook into.
 export function defineInterfaceCommand<ExecutorType extends BaseFunction>(description: {
     paramaters: IArgumentListParser,
-    table: string,
+    table: string|symbol,
     command: ExecutorType,
     designator: string[],
     summary: string,

--- a/src/commands/interface-manager/MatrixRoomReference.ts
+++ b/src/commands/interface-manager/MatrixRoomReference.ts
@@ -3,7 +3,10 @@
  * All rights reserved.
  */
 
-import { Permalinks, MatrixClient, RoomAlias } from "matrix-bot-sdk";
+import { Permalinks, RoomAlias } from "matrix-bot-sdk";
+
+type JoinRoom = (roomIdOrAlias: string, viaServers?: string[]) => Promise</*room id*/string>;
+type ResolveRoom = (roomIdOrAlias: string) => Promise</* room id */string>
 
 /**
  * This is a universal reference for a matrix room.
@@ -23,7 +26,7 @@ import { Permalinks, MatrixClient, RoomAlias } from "matrix-bot-sdk";
      * @param client A matrix client that should join the room.
      * @returns The room id that was joined.
      */
-    public async joinClient(client: MatrixClient): Promise<string> {
+    public async joinClient(client: { joinRoom: JoinRoom }): Promise<string> {
         return await client.joinRoom(this.reference, this.viaServers);
     }
 
@@ -56,7 +59,7 @@ import { Permalinks, MatrixClient, RoomAlias } from "matrix-bot-sdk";
      * @param client A client that we can use to resolve the room alias.
      * @returns A new MatrixRoomReference that contains the room id.
      */
-    public async resolve(client: MatrixClient): Promise<MatrixRoomReference> {
+    public async resolve(client: { resolveRoom: ResolveRoom }): Promise<MatrixRoomReference> {
         if (this.reference.startsWith('!')) {
             return this;
         } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,10 +273,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
   integrity sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==
 
-"@types/node@^16.7.10":
-  version "16.10.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.2.tgz#5764ca9aa94470adb4e1185fe2e9f19458992b2e"
-  integrity sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==
+"@types/node@^16.18.11":
+  version "16.18.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.11.tgz#cbb15c12ca7c16c85a72b6bdc4d4b01151bb3cae"
+  integrity sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==
 
 "@types/parse5@*":
   version "6.0.1"
@@ -3526,10 +3526,10 @@ typescript-formatter@^7.2:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
 
-typescript@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@^4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 ulidx@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
These are changes to the interface manager framework that we would need to be able to start migrating existing commands to use the framwork.

* htmlEscape text nodes
* support for keyword arguments