### PR TITLE
Do not `touch` version.txt if generating the version fails.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   "license": "SEE LICENSE IN LICENSE",
   "private": true,
   "scripts": {
-    "build": "tsc && (git describe > version.txt || true)",
-    "postbuild": "rm -rf lib/test/ && cp -r lib/src/* lib/ && rm -rf lib/src/",
+    "build": "tsc",
+    "postbuild": "yarn remove-tests-from-lib && yarn describe-version",
+    "describe-version": "(git describe > version.txt.tmp && mv version.txt.tmp version.txt) || true && rm -f version.txt.tmp",
+    "remove-tests-from-lib": "rm -rf lib/test/ && cp -r lib/src/* lib/ && rm -rf lib/src/",
     "lint": "tslint --project ./tsconfig.json -t stylish",
     "start:dev": "yarn build && node --async-stack-traces lib/index.js",
     "test": "ts-mocha --project ./tsconfig.json test/commands/**/*.ts",


### PR DESCRIPTION
Waisted a lot of time clowning around with this but this should be the end of the saga.