### PR TITLE
add .gitattributes & .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,11 @@ root = true
 
 [*]
 end_of_line = lf
+trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
The `.gitattributes` configuration requires everything that is detected as text to have `lf` line endings even when checked out.

The [`.editorconfig` configures capable text editors](https://editorconfig.org/#pre-installed) to

* use `lf` line endings
* remove trailing whitespace (with the exception of markdown files where it's valid way to end a paragraph?)
* insert a newline at end of file
* use the utf-8 charset
* use 4 spaces for indenting (instead of tabs)

while within this repository.

Signed-off-by: Aminda Suomalainen