### PR TITLE
Ban Propagation protection (that is enabled by default)

### DIFF
--- a/src/commands/interface-manager/DeadDocumentMatrix.ts
+++ b/src/commands/interface-manager/DeadDocumentMatrix.ts
@@ -79,7 +79,7 @@ export async function renderMatrix(node: DocumentNode, cb: SendMatrixEventCB): P
  * @param event An event to reply to.
  * @param client A MatrixClient to send the events with.
  */
-export async function renderMatrixAndSend(node: DocumentNode, roomId: string, event: any, client: MatrixSendClient): Promise<string[]> {
+export async function renderMatrixAndSend(node: DocumentNode, roomId: string, event: any|undefined, client: MatrixSendClient): Promise<string[]> {
     const baseContent = (text: string, html: string) => {
         return {
             msgtype: "m.notice",
@@ -91,11 +91,14 @@ export async function renderMatrixAndSend(node: DocumentNode, roomId: string, ev
     const renderInitialReply = async (text: string, html: string) => {
         return await client.sendMessage(roomId, {
             ...baseContent(text, html),
-            "m.relates_to": {
-                "m.in_reply_to": {
-                  "event_id": event['event_id']
+            ...event === undefined
+                ? {}
+                : { "m.relates_to": {
+                        "m.in_reply_to": {
+                            "event_id": event['event_id']
+                        }
+                    }
                 }
-            }
         })
     };
     const renderThreadReply = async (eventId: string, text: string, html: string) => {

--- a/src/commands/interface-manager/DeadDocumentMatrix.ts
+++ b/src/commands/interface-manager/DeadDocumentMatrix.ts
@@ -76,7 +76,7 @@ export async function renderMatrix(node: DocumentNode, cb: SendMatrixEventCB): P
  * Render the document node to html+text `m.notice` events.
  * @param node The document node to render.
  * @param roomId The room to send the events to.
- * @param event An event to reply to.
+ * @param event An event to reply to, if any.
  * @param client A MatrixClient to send the events with.
  */
 export async function renderMatrixAndSend(node: DocumentNode, roomId: string, event: any|undefined, client: MatrixSendClient): Promise<string[]> {
@@ -92,7 +92,7 @@ export async function renderMatrixAndSend(node: DocumentNode, roomId: string, ev
         return await client.sendMessage(roomId, {
             ...baseContent(text, html),
             ...event === undefined
-                ? {}
+                ? {} // if they don't supply a reply just send a top level event.
                 : { "m.relates_to": {
                         "m.in_reply_to": {
                             "event_id": event['event_id']

--- a/src/commands/interface-manager/MatrixHelpRenderer.tsx
+++ b/src/commands/interface-manager/MatrixHelpRenderer.tsx
@@ -106,3 +106,8 @@ function renderCommandException(command: InterfaceCommand<BaseFunction>, error: 
         to an administrator.
     </root>
 }
+
+export function renderMentionPill(mxid: string, displayName: string): DocumentNode {
+    const url = `https://matrix.to/#/${mxid}`;
+    return <a href={url}>{displayName}</a>
+}

--- a/src/commands/interface-manager/MatrixPromptUX.ts
+++ b/src/commands/interface-manager/MatrixPromptUX.ts
@@ -106,14 +106,16 @@ class ReactionHandler {
         roomId: string, eventId: string, presentationByReaction: PresentationByReactionKey, timeout = 600_000 // ten minutes
     ): Promise<CommandResult<T, CommandError>> {
         let record;
+        let timeoutId;
         const presentationOrTimeout = await Promise.race([
             new Promise(resolve => {
                 record = new ReactionPromptRecord(presentationByReaction, resolve);
                 this.addPresentationsForEvent(eventId, record);
                 this.addBaseReactionsToEvent(roomId, eventId, presentationByReaction);
             }),
-            new Promise(resolve => setTimeout(resolve, timeout)),
+            new Promise(resolve => timeoutId = setTimeout(resolve, timeout)),
         ]);
+        clearTimeout(timeoutId);
         if (presentationOrTimeout === undefined) {
             if (record !== undefined) {
                 this.removePromptRecordForEvent(eventId, record);

--- a/src/protections/BanPropagation.tsx
+++ b/src/protections/BanPropagation.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2022-2023 Gnuxie <Gnuxie@protonmail.com>
+ * All rights reserved.
+ *
+ * This file is modified and is NOT licensed under the Apache License.
+ * This modified file incorperates work from mjolnir
+ * https://github.com/matrix-org/mjolnir
+ * which included the following license notice:
+
+Copyright 2019-2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ *
+ * However, this file is modified and the modifications in this file
+ * are NOT distributed, contributed, committed, or licensed under the Apache License.
+ */
+
+import { Protection } from "./IProtection";
+import { Mjolnir } from "../Mjolnir";
+import { LogService } from "matrix-bot-sdk";
+import { PromptResponseListener } from "../commands/interface-manager/MatrixPromptUX";
+import { JSXFactory } from "../commands/interface-manager/JSXFactory";
+import { renderMatrixAndSend } from "../commands/interface-manager/DeadDocumentMatrix";
+import { renderMentionPill } from "../commands/interface-manager/MatrixHelpRenderer";
+import { RULE_USER } from "../models/ListRule";
+
+/**
+ * This could not be implemented as a protection for the following reasons:
+ * - To enable a protection by default would require a significant refactor
+ * - For some reason bans aren't showing in the protection manager via room.event?
+ */
+
+/**
+ * Prompt the management room to propagate a user ban to a policy list of their choice.
+ * @param mjolnir Mjolnir.
+ * @param event The ban event.
+ * @param roomId The room that the ban happened in.
+ * @returns An event id which can be used by the `PromptResponseListener`.
+ */
+async function promptBanPropagation(
+    mjolnir: Mjolnir,
+    event: any,
+    roomId: string
+): Promise</*event id*/string> {
+    return (await renderMatrixAndSend(
+        <root>The user {renderMentionPill(event["state_key"], event["content"]?.["displayname"] ?? event["state_key"])} was banned
+                in <a href={`https://matrix.to/#/${roomId}`}>{roomId}</a> for <code>{event["content"]?.["reason"] ?? '<no reason supplied>'}</code>.<br/>
+                Would you like to add the ban to a policy list?
+            <ol>
+                {mjolnir.policyListManager.lists.map(list => <li>{list}</li>)}
+            </ol>
+        </root>,
+        mjolnir.managementRoomId,
+        undefined,
+        mjolnir.client
+    )).at(0) as string;
+}
+
+export class BanPropagation extends Protection {
+
+    settings = {};
+
+    public get name(): string {
+        return 'BanPropagationProtection';
+    }
+    public get description(): string {
+        return "When you ban a user in any protected room with a client, this protection\
+        will turn the room level ban into a policy for a policy list of your choice.\
+        This will then allow the bot to ban the user from all of your rooms.";
+    }
+
+    // TODO: for the automated version we should check that the sender is in the management room.
+    // TODO: I really want this to be enabled by default.
+    public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
+        if (event['type'] === 'm.room.member' && event['content']?.['membership'] === 'ban') {
+            const promptListener = new PromptResponseListener(
+                mjolnir.matrixEmitter,
+                await mjolnir.client.getUserId(),
+                mjolnir.client
+            );
+            // do not await, we don't want to block the protection manager
+            promptListener.waitForPresentationList(
+                mjolnir.policyListManager.lists,
+                mjolnir.managementRoomId,
+                promptBanPropagation(mjolnir, event, roomId)
+            ).then(listResult => {
+                if (listResult.isOk()) {
+                    const list = listResult.ok;
+                    return list.banEntity(RULE_USER, event['state_key'], event['content']?.["reason"]);
+                } else {
+                    LogService.warn("BanPropagation", "Timed out waiting for a response to a room level ban", listResult.err);
+                    return;
+                }
+            }).catch(e => {
+                LogService.error('BanPropagation', "Encountered an error while prompting the user for instructions to propagate a room level ban", e);
+            });
+        }
+    }
+}

--- a/src/protections/ProtectionManager.ts
+++ b/src/protections/ProtectionManager.ts
@@ -41,9 +41,11 @@ import { Consequence } from "./consequence";
 import { htmlEscape } from "../utils";
 import { ERROR_KIND_FATAL, ERROR_KIND_PERMISSION } from "../ErrorCache";
 import { RoomUpdateError } from "../models/RoomUpdateError";
+import { BanPropagation } from "./BanPropagation";
 
 const PROTECTIONS: Protection[] = [
     new FirstMessageIsImage(),
+    new BanPropagation(),
     new BasicFlooding(),
     new WordList(),
     new MessageIsVoice(),

--- a/test/integration/banPropagationTest.ts
+++ b/test/integration/banPropagationTest.ts
@@ -1,0 +1,58 @@
+import expect from "expect";
+import { Mjolnir } from "../../src/Mjolnir";
+import { newTestUser } from "./clientHelper";
+import { getFirstEventMatching } from './commands/commandUtils';
+import { Permalinks } from "matrix-bot-sdk";
+import { RULE_USER } from "../../src/models/ListRule";
+
+// We will need to disable this in tests that are banning people otherwise it will cause
+// mocha to hang for awhile until it times out waiting for a response to a prompt.
+describe("Ban propagation test", function() {
+    it("Should be enabled by default", async function() {
+        const mjolnir: Mjolnir = this.mjolnir
+        expect(mjolnir.protectionManager.getProtection("BanPropagationProtection")?.enabled).toBeTruthy();
+    })
+    it("Should prompt to add bans to a policy list, then add the ban", async function() {
+        const mjolnir: Mjolnir = this.mjolnir
+        const mjolnirId = await mjolnir.client.getUserId();
+        const moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        await moderator.joinRoom(mjolnir.managementRoomId);
+        const protectedRooms = await Promise.all([...Array(5)].map(async _ => {
+            const room = await moderator.createRoom({ invite: [mjolnirId] });
+            await mjolnir.client.joinRoom(room);
+            await moderator.setUserPowerLevel(mjolnirId, room, 100);
+            await mjolnir.addProtectedRoom(room);
+            return room;
+        }));
+        // create a policy list so that we can check it for a user rule later
+        const policyListId = await moderator.createRoom({ invite: [mjolnirId] });
+        await moderator.setUserPowerLevel(mjolnirId, policyListId, 100);
+        await mjolnir.client.joinRoom(policyListId);
+        await mjolnir.policyListManager.watchList(Permalinks.forRoom(policyListId));
+
+        // check for the prompt
+        const promptEvent = await getFirstEventMatching({
+            matrix: mjolnir.matrixEmitter,
+            targetRoom: mjolnir.managementRoomId,
+            lookAfterEvent: async function () {
+                // ban a user in one of our protected rooms using the moderator
+                await moderator.banUser('@test:example.com', protectedRooms[0], "spam");
+                return undefined;
+            },
+            predicate: function (event: any): boolean {
+                return (event['content']?.['body'] ?? '').startsWith('The user')
+            }
+        })
+        // select the prompt
+        await moderator.unstableApis.addReactionToEvent(
+            mjolnir.managementRoomId, promptEvent['event_id'], '1.'
+        );
+        // check the policy list, after waiting a few seconds.
+        await new Promise(resolve => setTimeout(resolve, 10000));
+        const policyList = mjolnir.policyListManager.lists[0];
+        const rules = policyList.rulesMatchingEntity('@test:example.com', RULE_USER);
+        expect(rules.length).toBe(1);
+        expect(rules[0].entity).toBe('@test:example.com');
+        expect(rules[0].reason).toBe('spam');
+    })
+})

--- a/test/integration/commands/commandUtils.ts
+++ b/test/integration/commands/commandUtils.ts
@@ -118,11 +118,20 @@ export async function getFirstReaction(matrix: MatrixEmitter, targetRoom: string
     }
 }
 
+/**
+ * Get and wait for the first event that matches a predicate.
+ * @param details.lookAfterEvent A function that returns an event id to look for
+ * in the sync timeline before matching. Or a function that returns undefined if
+ * `getFirstEventMatching` should start matching events right away.
+ * @returns The event matching the predicate provided.
+ */
 export async function getFirstEventMatching(details: { matrix: MatrixEmitter, targetRoom: string, lookAfterEvent: () => Promise</*event id*/string|undefined>, predicate: (event: any) => boolean }): Promise<any> {
-    let targetCb = undefined;
+    let targetCb;
     try {
         return await new Promise((resolve, reject) => {
             details.lookAfterEvent().then((afterEventId: string|undefined) => {
+                // if the event has returned an event id, then we will wait for that in the timeline,
+                // otherwise the "event" isn't a matrix event and we just have to start looking right away.
                 let isAfterEventId = afterEventId === undefined;
                 targetCb = (roomId: string, event: any) => {
                     if (event['event_id'] === afterEventId) {

--- a/test/integration/roomMembersTest.ts
+++ b/test/integration/roomMembersTest.ts
@@ -257,6 +257,7 @@ describe("Test: Testing RoomMemberManager", function() {
         this.timeout(60000);
         const start = new Date(Date.now() - 10_000);
         const mjolnir: Mjolnir = this.mjolnir!;
+        mjolnir.protectionManager.disableProtection("BanPropagationProtection"); // don't respond to room level bans.
 
         // Setup a moderator.
         this.moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });


### PR DESCRIPTION
Inspired by https://github.com/matrix-org/mjolnir/pull/223

![image](https://user-images.githubusercontent.com/50846879/220681720-6764d94c-ba9c-4f83-a61d-f1d7c1efcdc7.png)


Later on it should be configurable so that it can automatically add the ban to a list.
In that situation it should also try show the last message of the banned user behind spoiler text so that there is some context for other moderators