### PR TITLE
PolicyListManager watch/unwatch should use MatrixRoomReferences.

### DIFF
--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -10,6 +10,7 @@ import { randomUUID } from "crypto";
 import EventEmitter from "events";
 import { MatrixEmitter } from "../MatrixEmitter";
 import { Permalinks } from "../commands/interface-manager/Permalinks";
+import { MatrixRoomReference } from "../commands/interface-manager/MatrixRoomReference";
 
 const log = new Logger('MjolnirManager');
 
@@ -238,7 +239,7 @@ export class ManagedMjolnir {
             [mjolnirOwnerId],
             { name: `${mjolnirOwnerId}'s policy room` }
         );
-        const roomRef = Permalinks.forRoom(listRoomId);
+        const roomRef = MatrixRoomReference.fromPermalink(Permalinks.forRoom(listRoomId));
         await this.mjolnir.addProtectedRoom(listRoomId);
         return await this.mjolnir.policyListManager.watchList(roomRef);
     }

--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -31,7 +31,6 @@ import { LogService, RichReply } from "matrix-bot-sdk";
 import { execSyncCommand } from "./SyncCommand";
 import { execPermissionCheckCommand } from "./PermissionCheckCommand";
 import { execCreateListCommand } from "./CreateBanListCommand";
-import { execUnwatchCommand, execWatchCommand } from "./WatchUnwatchCommand";
 import { execRedactCommand } from "./RedactCommand";
 import { execImportCommand } from "./ImportCommand";
 import { execSetDefaultListCommand } from "./SetDefaultBanListCommand";
@@ -73,6 +72,7 @@ import "./Ban";
 import "./Unban";
 import "./StatusCommand";
 import "./Rules";
+import "./WatchUnwatchCommand";
 import "./Help";
 
 export const COMMAND_PREFIX = "!mjolnir";
@@ -94,10 +94,6 @@ export async function handleCommand(roomId: string, event: { content: { body: st
             return await execPermissionCheckCommand(roomId, event, mjolnir);
         } else if (parts.length >= 5 && parts[1] === 'list' && parts[2] === 'create') {
             return await execCreateListCommand(roomId, event, mjolnir, parts);
-        } else if (parts[1] === 'watch' && parts.length > 1) {
-            return await execWatchCommand(roomId, event, mjolnir, parts);
-        } else if (parts[1] === 'unwatch' && parts.length > 1) {
-            return await execUnwatchCommand(roomId, event, mjolnir, parts);
         } else if (parts[1] === 'redact' && parts.length > 1) {
             return await execRedactCommand(roomId, event, mjolnir, parts);
         } else if (parts[1] === 'import' && parts.length > 2) {

--- a/src/commands/CreateBanListCommand.ts
+++ b/src/commands/CreateBanListCommand.ts
@@ -29,6 +29,7 @@ import { Mjolnir } from "../Mjolnir";
 import PolicyList from "../models/PolicyList";
 import { RichReply } from "matrix-bot-sdk";
 import { Permalinks } from "./interface-manager/Permalinks";
+import { MatrixRoomReference } from "./interface-manager/MatrixRoomReference";
 
 // !mjolnir list create <shortcode> <alias localpart>
 export async function execCreateListCommand(roomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
@@ -42,7 +43,7 @@ export async function execCreateListCommand(roomId: string, event: any, mjolnir:
         { room_alias_name: aliasLocalpart }
     );
 
-    const roomRef = Permalinks.forRoom(listRoomId);
+    const roomRef = MatrixRoomReference.fromPermalink(Permalinks.forRoom(listRoomId));
     await mjolnir.policyListManager.watchList(roomRef);
     await mjolnir.addProtectedRoom(listRoomId);
 

--- a/src/commands/Help.tsx
+++ b/src/commands/Help.tsx
@@ -44,8 +44,6 @@ const oldHelpMenu = "" +
 "!mjolnir sync                                                       - Force updates of all lists and re-apply rules\n" +
 "!mjolnir verify                                                     - Ensures Mjolnir can moderate all your rooms\n" +
 "!mjolnir list create <shortcode> <alias localpart>                  - Creates a new ban list with the given shortcode and alias\n" +
-"!mjolnir watch <room alias/ID>                                      - Watches a ban list\n" +
-"!mjolnir unwatch <room alias/ID>                                    - Unwatches a ban list\n" +
 "!mjolnir import <room alias/ID> <list shortcode>                    - Imports bans and ACLs into the given list\n" +
 "!mjolnir default <shortcode>                                        - Sets the default list for commands\n" +
 "!mjolnir protections                                                - List all available protections\n" +

--- a/test/integration/banListTest.ts
+++ b/test/integration/banListTest.ts
@@ -10,6 +10,7 @@ import { ALL_RULE_TYPES, Recommendation, RULE_SERVER, RULE_USER, SERVER_RULE_TYP
 import AccessControlUnit, { Access, EntityAccess } from "../../src/models/AccessControlUnit";
 import { randomUUID } from "crypto";
 import { MatrixSendClient } from "../../src/MatrixEmitter";
+import { MatrixRoomReference } from "../../src/commands/interface-manager/MatrixRoomReference";
 
 /**
  * Create a policy rule in a policy room.
@@ -262,7 +263,7 @@ describe('Test: ACL updates will batch when rules are added in succession.', fun
         // Flood the watched list with banned servers, which should prompt Mjolnir to update server ACL in protected rooms.
         const banListId = await moderator.createRoom({ invite: [mjolnirId] });
         await mjolnir.client.joinRoom(banListId);
-        await mjolnir.policyListManager.watchList(Permalinks.forRoom(banListId));
+        await mjolnir.policyListManager.watchList(MatrixRoomReference.fromRoomId(banListId));
         const acl = new ServerAcl(serverName).denyIpAddresses().allowServer("*");
         const evilServerCount = 200;
         for (let i = 0; i < evilServerCount; i++) {
@@ -327,7 +328,7 @@ describe('Test: unbaning entities via the PolicyList.', function() {
         await moderator.setUserPowerLevel(await mjolnir.client.getUserId(), banListId, 100);
         await moderator.sendStateEvent(banListId, 'org.matrix.mjolnir.shortcode', '', { shortcode: "unban-test" });
         await mjolnir.client.joinRoom(banListId);
-        await mjolnir.policyListManager.watchList(Permalinks.forRoom(banListId));
+        await mjolnir.policyListManager.watchList(MatrixRoomReference.fromRoomId(banListId));
         // we use this to compare changes.
         const banList = new PolicyList(banListId, banListId, moderator);
         // we need two because we need to test the case where an entity has all rule types in the list
@@ -402,7 +403,7 @@ describe('Test: should apply bans to the most recently active rooms first', func
         // Flood the watched list with banned servers, which should prompt Mjolnir to update server ACL in protected rooms.
         const banListId = await moderator.createRoom({ invite: [mjolnirId] });
         await mjolnir.client.joinRoom(banListId);
-        await mjolnir.policyListManager.watchList(Permalinks.forRoom(banListId));
+        await mjolnir.policyListManager.watchList(MatrixRoomReference.fromRoomId(banListId));
 
         await mjolnir.protectedRoomsTracker.syncLists();
 
@@ -506,7 +507,7 @@ describe('Test: AccessControlUnit interaction with policy lists.', function() {
         assertAccess(Access.Allowed, aclUnit.getAccessForUser('@someone:matrix.org', "CHECK_SERVER"));
 
         // protect a room and check that only bad.example.com, *.ddns.example.com are in the deny ACL and not matrix.org
-        await mjolnir.policyListManager.watchList(policyList.roomRef);
+        await mjolnir.policyListManager.watchList(MatrixRoomReference.fromPermalink(policyList.roomRef));
         const protectedRoom = await mjolnir.client.createRoom();
         await mjolnir.protectedRoomsTracker.addProtectedRoom(protectedRoom);
         await mjolnir.protectedRoomsTracker.syncLists();

--- a/test/integration/banPropagationTest.ts
+++ b/test/integration/banPropagationTest.ts
@@ -2,8 +2,8 @@ import expect from "expect";
 import { Mjolnir } from "../../src/Mjolnir";
 import { newTestUser } from "./clientHelper";
 import { getFirstEventMatching } from './commands/commandUtils';
-import { Permalinks } from "matrix-bot-sdk";
 import { RULE_USER } from "../../src/models/ListRule";
+import { MatrixRoomReference } from "../../src/commands/interface-manager/MatrixRoomReference";
 
 // We will need to disable this in tests that are banning people otherwise it will cause
 // mocha to hang for awhile until it times out waiting for a response to a prompt.
@@ -28,7 +28,7 @@ describe("Ban propagation test", function() {
         const policyListId = await moderator.createRoom({ invite: [mjolnirId] });
         await moderator.setUserPowerLevel(mjolnirId, policyListId, 100);
         await mjolnir.client.joinRoom(policyListId);
-        await mjolnir.policyListManager.watchList(Permalinks.forRoom(policyListId));
+        await mjolnir.policyListManager.watchList(MatrixRoomReference.fromRoomId(policyListId));
 
         // check for the prompt
         const promptEvent = await getFirstEventMatching({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,8 @@
         "./test/integration/banListTest.ts",
         "./test/integration/reportPollingTest",
         "./test/integration/policyConsumptionTest.ts",
-        "./test/integration/protectionSettingsTest.ts"
+        "./test/integration/protectionSettingsTest.ts",
+        "./test/integration/banPropagationTest.ts",
+        "./test/integration/protectedRoomsConfigTest.ts",
     ]
 }


### PR DESCRIPTION
This simplifies the code for joining and watching a policy list from an alias.