### PR TITLE
Typo unwatching lists.

### DIFF
--- a/src/models/AccessControlUnit.ts
+++ b/src/models/AccessControlUnit.ts
@@ -241,7 +241,7 @@ export default class AccessControlUnit {
 
     public unwatchList(list: PolicyList) {
         for (const cache of this.caches) {
-            cache.watchList(list);
+            cache.unwatchList(list);
         }
     }
 


### PR DESCRIPTION
This is actually really bad.
For multiple reasons.
The best way for this to be avoided is to drop everything and reload it when the account data for watched lists is changed. Then there isn't a situation where you have to inform anyone about a change in what lists are being watched.