### PR TITLE
Fix an issue where protected rooms could not be removed.

### DIFF
--- a/src/commands/Help.tsx
+++ b/src/commands/Help.tsx
@@ -53,9 +53,6 @@ const oldHelpMenu = "" +
 "!mjolnir config add <protection>.<setting> [value]                  - Add a value to a list protection setting\n" +
 "!mjolnir config remove <protection>.<setting> [value]               - Remove a value from a list protection setting\n" +
 "!mjolnir config get [protection]                                    - List protection settings\n" +
-"!mjolnir rooms                                                      - Lists all the protected rooms\n" +
-"!mjolnir rooms add <room alias/ID>                                  - Adds a protected room (may cause high server load)\n" +
-"!mjolnir rooms remove <room alias/ID>                               - Removes a protected room\n" +
 "!mjolnir resolve <room alias>                                       - Resolves a room alias to a room ID\n" +
 "!mjolnir since <date>/<duration> <action> <limit> [rooms...] [reason] - Apply an action ('kick', 'ban', 'mute', 'unmute' or 'show') to all users who joined a room since <date>/<duration> (up to <limit> users)\n" +
 "!mjolnir powerlevel <user ID> <power level> [room alias/ID]         - Sets the power level of the user in the specified room (or all protected rooms)\n" +

--- a/src/commands/Rooms.tsx
+++ b/src/commands/Rooms.tsx
@@ -117,6 +117,7 @@ defineInterfaceCommand({
     ]),
     command: async function (this: MjolnirContext, _keywords, roomRef: MatrixRoomReference): Promise<CommandResult<void>> {
         const roomID = await roomRef.resolve(this.mjolnir.client);
+        await this.mjolnir.removeProtectedRoom(roomID.toRoomIdOrAlias());
         try {
             await this.mjolnir.client.leaveRoom(roomID.toRoomIdOrAlias());
         } catch (exception) {

--- a/test/integration/commands/roomsTest.ts
+++ b/test/integration/commands/roomsTest.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from "assert";
+import { newTestUser } from "../clientHelper";
+import { getFirstReaction, getFirstReply } from "./commandUtils";
+
+ describe("Test: The rooms commands", function () {
+    // If a test has a timeout while awaitng on a promise then we never get given control back.
+    afterEach(function() { this.moderator?.stop(); });
+
+    it('Mjolnir can protect a room, show that it is protected and then stop protecting the room.', async function() {
+        // Create a few users and a room.
+        const mjolnir = this.mjolnir.client;
+        let mjolnirUserId = await mjolnir.getUserId();
+        let moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        this.moderator = moderator;
+        await moderator.joinRoom(this.config.managementRoom);
+        let targetRoom = await moderator.createRoom({ invite: [mjolnirUserId]});
+        await moderator.setUserPowerLevel(mjolnirUserId, targetRoom, 100);
+
+        try {
+            await moderator.start();
+            await getFirstReaction(moderator, this.mjolnir.managementRoomId, '✅', async () => {
+                return await moderator.sendMessage(this.mjolnir.managementRoomId, {msgtype: 'm.text', body: `!mjolnir rooms add ${targetRoom}`});
+            });
+            let protectedRoomsMessage = await getFirstReply(moderator, this.mjolnir.managementRoomId, async () => {
+                return await moderator.sendMessage(this.mjolnir.managementRoomId, {msgtype: 'm.text', body: `!mjolnir rooms`});
+            })
+            assert.equal(protectedRoomsMessage['content']?.['body']?.includes('1'), true, "There should be one protected room");
+            await getFirstReaction(moderator, this.mjolnir.managementRoomId, '✅', async () => {
+                return await moderator.sendMessage(this.mjolnir.managementRoomId, {msgtype: 'm.text', body: `!mjolnir rooms remove ${targetRoom}`});
+            });
+            protectedRoomsMessage = await getFirstReply(moderator, this.mjolnir.managementRoomId, async () => {
+                return await moderator.sendMessage(this.mjolnir.managementRoomId, {msgtype: 'm.text', body: `!mjolnir rooms`});
+            })
+            assert.equal(protectedRoomsMessage['content']?.['body']?.includes('0'), true, "There room should no longer be protected");
+        } finally {
+            moderator.stop();
+        }
+    })
+})

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -1,4 +1,5 @@
 import { read as configRead } from "../../src/config";
+import { WATCHED_LISTS_EVENT_TYPE } from "../../src/models/PolicyList";
 import { patchMatrixClient } from "../../src/utils";
 import { makeMjolnir, teardownManagementRoom } from "./mjolnirSetupUtils";
 
@@ -22,7 +23,7 @@ export const mochaHooks = {
             config.RUNTIME.client = this.mjolnir.client;
             await Promise.all([
                 this.mjolnir.client.setAccountData('org.matrix.mjolnir.protected_rooms', { rooms: [] }),
-                this.mjolnir.client.setAccountData('org.matrix.mjolnir.watched_lists', { references: [] }),
+                this.mjolnir.client.setAccountData(WATCHED_LISTS_EVENT_TYPE,  { references: [] }),
             ]);
             await this.mjolnir.start();
             console.log("mochaHooks.beforeEach DONE");
@@ -34,7 +35,7 @@ export const mochaHooks = {
             await this.mjolnir.stop();
             await Promise.all([
                 this.mjolnir.client.setAccountData('org.matrix.mjolnir.protected_rooms', { rooms: [] }),
-                this.mjolnir.client.setAccountData('org.matrix.mjolnir.watched_lists', { references: [] }),
+                this.mjolnir.client.setAccountData(WATCHED_LISTS_EVENT_TYPE, { references: [] }),
             ]);
             // remove alias from management room and leave it.
             await teardownManagementRoom(this.mjolnir.client, this.mjolnir.managementRoomId, this.managementRoomAlias);


### PR DESCRIPTION
This was introduced in https://github.com/Gnuxie/Draupnir/pull/54/ (and therefore 1.83.0). Essentially we forgot to remove the room from the protected rooms set, when the remove command was used.

Ontop of this something to note is that during testing it is clear that the protected rooms set is loaded when configuring mjolnir, not when starting it. This is problematic as it means setup code in `fixtures.ts` does not actually wipe the protected rooms set.