### PR TITLE
Add health endpoint to appservice and add metrics via prometheus

### DIFF
--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -12,7 +12,7 @@ import { MatrixEmitter } from "../MatrixEmitter";
 import { Permalinks } from "../commands/interface-manager/Permalinks";
 import { MatrixRoomReference } from "../commands/interface-manager/MatrixRoomReference";
 import { Gauge } from "prom-client";
-import { decrementGuageValue, incrementGuageValue } from "../utils";
+import { decrementGaugeValue, incrementGaugeValue } from "../utils";
 
 const log = new Logger('MjolnirManager');
 
@@ -73,9 +73,9 @@ export class MjolnirManager {
         await managedMjolnir.start();
         this.mjolnirs.set(mxid, managedMjolnir);
         this.unstartedMjolnirs.delete(mxid);
-        incrementGuageValue(this.instanceCountGauge, "offline", localPart);
-        decrementGuageValue(this.instanceCountGauge, "disabled", localPart);
-        incrementGuageValue(this.instanceCountGauge, "online", localPart);
+        incrementGaugeValue(this.instanceCountGauge, "offline", localPart);
+        decrementGaugeValue(this.instanceCountGauge, "disabled", localPart);
+        incrementGaugeValue(this.instanceCountGauge, "online", localPart);
         return managedMjolnir;
     }
 
@@ -194,8 +194,8 @@ export class MjolnirManager {
             // Don't await, we don't want to clobber initialization just because we can't tell someone they're no longer allowed.
             mjIntent.matrixClient.sendNotice(mjolnirRecord.management_room, `Your mjolnir has been disabled by the administrator: ${access.rule?.reason ?? "no reason supplied"}`);
             this.reportUnstartedMjolnir(UnstartedMjolnir.FailCode.Unauthorized, access.outcome, mjolnirRecord, mjIntent.userId);
-            decrementGuageValue(this.instanceCountGauge, "online", mjolnirRecord.local_part);
-            incrementGuageValue(this.instanceCountGauge, "disabled", mjolnirRecord.local_part);
+            decrementGaugeValue(this.instanceCountGauge, "online", mjolnirRecord.local_part);
+            incrementGaugeValue(this.instanceCountGauge, "disabled", mjolnirRecord.local_part);
         } else {
             await this.makeInstance(
                 mjolnirRecord.local_part,
@@ -207,8 +207,8 @@ export class MjolnirManager {
                 // Don't await, we don't want to clobber initialization if this fails.
                 mjIntent.matrixClient.sendNotice(mjolnirRecord.management_room, `Your mjolnir could not be started. Please alert the administrator`);
                 this.reportUnstartedMjolnir(UnstartedMjolnir.FailCode.StartError, e, mjolnirRecord, mjIntent.userId);
-                decrementGuageValue(this.instanceCountGauge, "online", mjolnirRecord.local_part);
-                incrementGuageValue(this.instanceCountGauge, "offline", mjolnirRecord.local_part);
+                decrementGaugeValue(this.instanceCountGauge, "online", mjolnirRecord.local_part);
+                incrementGaugeValue(this.instanceCountGauge, "offline", mjolnirRecord.local_part);
             });
         }
     }

--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -11,6 +11,7 @@ import EventEmitter from "events";
 import { MatrixEmitter } from "../MatrixEmitter";
 import { Permalinks } from "../commands/interface-manager/Permalinks";
 import { MatrixRoomReference } from "../commands/interface-manager/MatrixRoomReference";
+import { Gauge } from "prom-client";
 
 const log = new Logger('MjolnirManager');
 
@@ -30,7 +31,8 @@ export class MjolnirManager {
     private constructor(
         private readonly dataStore: DataStore,
         private readonly bridge: Bridge,
-        private readonly accessControl: AccessControl
+        private readonly accessControl: AccessControl,
+        private readonly instanceCountGauge: Gauge<"status" | "uuid">
     ) {
 
     }
@@ -42,8 +44,8 @@ export class MjolnirManager {
      * @param accessControl Who has access to the bridge.
      * @returns A new mjolnir manager.
      */
-    public static async makeMjolnirManager(dataStore: DataStore, bridge: Bridge, accessControl: AccessControl): Promise<MjolnirManager> {
-        const mjolnirManager = new MjolnirManager(dataStore, bridge, accessControl);
+    public static async makeMjolnirManager(dataStore: DataStore, bridge: Bridge, accessControl: AccessControl, instanceCountGauge: Gauge<"status" | "uuid">): Promise<MjolnirManager> {
+        const mjolnirManager = new MjolnirManager(dataStore, bridge, accessControl, instanceCountGauge);
         await mjolnirManager.startMjolnirs(await dataStore.list());
         return mjolnirManager;
     }
@@ -55,7 +57,7 @@ export class MjolnirManager {
      * @param client A client for the appservice virtual user that the new mjolnir should use.
      * @returns A new managed mjolnir.
      */
-    public async makeInstance(requestingUserId: string, managementRoomId: string, client: MatrixClient): Promise<ManagedMjolnir> {
+    public async makeInstance(localPart: string, requestingUserId: string, managementRoomId: string, client: MatrixClient): Promise<ManagedMjolnir> {
         const mxid = await client.getUserId();
         const intentListener = new MatrixIntentListener(mxid);
         const managedMjolnir = new ManagedMjolnir(
@@ -70,6 +72,18 @@ export class MjolnirManager {
         await managedMjolnir.start();
         this.mjolnirs.set(mxid, managedMjolnir);
         this.unstartedMjolnirs.delete(mxid);
+        // @ts-ignore
+        if (this.instanceCountGauge._getValue({ status: "offline", uuid: localPart })) {
+            this.instanceCountGauge.dec({ status: "offline", uuid: localPart });
+        }
+        // @ts-ignore
+        if (this.instanceCountGauge._getValue({ status: "disabled", uuid: localPart })) {
+            this.instanceCountGauge.dec({ status: "disabled", uuid: localPart });
+        }
+        // @ts-ignore
+        if (!this.instanceCountGauge._getValue({ status: "online", uuid: localPart })) {
+            this.instanceCountGauge.inc({ status: "online", uuid: localPart });
+        }
         return managedMjolnir;
     }
 
@@ -79,7 +93,7 @@ export class MjolnirManager {
      * @param ownerId The owner of the mjolnir. We ask for it explicitly to not leak access to another user's mjolnir.
      * @returns The matching managed mjolnir instance.
      */
-    public getMjolnir(mjolnirId: string, ownerId: string): ManagedMjolnir|undefined {
+    public getMjolnir(mjolnirId: string, ownerId: string): ManagedMjolnir | undefined {
         const mjolnir = this.mjolnirs.get(mjolnirId);
         if (mjolnir) {
             if (mjolnir.ownerId !== ownerId) {
@@ -134,7 +148,7 @@ export class MjolnirManager {
                 name: `${requestingUserId}'s mjolnir`
             });
 
-            const mjolnir = await this.makeInstance(requestingUserId, managementRoomId, mjIntent.matrixClient);
+            const mjolnir = await this.makeInstance(mjolnirLocalPart, requestingUserId, managementRoomId, mjIntent.matrixClient);
             await mjolnir.createFirstList(requestingUserId, "list");
 
             await this.dataStore.store({
@@ -157,7 +171,7 @@ export class MjolnirManager {
         return [...this.unstartedMjolnirs.values()];
     }
 
-    public findUnstartedMjolnir(localPart: string): UnstartedMjolnir|undefined {
+    public findUnstartedMjolnir(localPart: string): UnstartedMjolnir | undefined {
         return [...this.unstartedMjolnirs.values()].find(unstarted => unstarted.mjolnirRecord.local_part === localPart);
     }
 
@@ -188,8 +202,17 @@ export class MjolnirManager {
             // Don't await, we don't want to clobber initialization just because we can't tell someone they're no longer allowed.
             mjIntent.matrixClient.sendNotice(mjolnirRecord.management_room, `Your mjolnir has been disabled by the administrator: ${access.rule?.reason ?? "no reason supplied"}`);
             this.reportUnstartedMjolnir(UnstartedMjolnir.FailCode.Unauthorized, access.outcome, mjolnirRecord, mjIntent.userId);
+            // @ts-ignore
+            if (this.instanceCountGauge._getValue({ status: "online", uuid: mjolnirRecord.local_part })) {
+                this.instanceCountGauge.dec({ status: "online", uuid: mjolnirRecord.local_part });
+            }
+            // @ts-ignore
+            if (!this.instanceCountGauge._getValue({ status: "disabled", uuid: mjolnirRecord.local_part })) {
+                this.instanceCountGauge.inc({ status: "disabled", uuid: mjolnirRecord.local_part });
+            }
         } else {
             await this.makeInstance(
+                mjolnirRecord.local_part,
                 mjolnirRecord.owner,
                 mjolnirRecord.management_room,
                 mjIntent.matrixClient,
@@ -198,6 +221,14 @@ export class MjolnirManager {
                 // Don't await, we don't want to clobber initialization if this fails.
                 mjIntent.matrixClient.sendNotice(mjolnirRecord.management_room, `Your mjolnir could not be started. Please alert the administrator`);
                 this.reportUnstartedMjolnir(UnstartedMjolnir.FailCode.StartError, e, mjolnirRecord, mjIntent.userId);
+                // @ts-ignore
+                if (this.instanceCountGauge._getValue({ status: "online", uuid: mjolnirRecord.local_part })) {
+                    this.instanceCountGauge.dec({ status: "online", uuid: mjolnirRecord.local_part });
+                }
+                // @ts-ignore
+                if (!this.instanceCountGauge._getValue({ status: "offline", uuid: mjolnirRecord.local_part })) {
+                    this.instanceCountGauge.inc({ status: "offline", uuid: mjolnirRecord.local_part });
+                }
             });
         }
     }
@@ -272,7 +303,7 @@ export class MatrixIntentListener extends EventEmitter implements MatrixEmitter 
     public handleEvent(mxEvent: WeakEvent) {
         // These are ordered to be the same as matrix-bot-sdk's MatrixClient
         // They shouldn't need to be, but they are just in case it matters.
-        if (mxEvent['type'] === 'm.room.member' &&  mxEvent.state_key === this.mjolnirId) {
+        if (mxEvent['type'] === 'm.room.member' && mxEvent.state_key === this.mjolnirId) {
             if (mxEvent['content']['membership'] === 'leave') {
                 this.emit('room.leave', mxEvent.room_id, mxEvent);
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,11 +73,11 @@ export function setToArray<T>(set: Set<T>): T[] {
 
 /**
  * This increments a prometheus gauge. Used in the Appservice MjolnirManager.
- * 
+ *
  * The ts-ignore is mandatory since we access a private method due to lack of a public one.
- * 
+ *
  * See https://github.com/Gnuxie/Draupnir/pull/70#discussion_r1299188922
- * 
+ *
  * @param gauge The Gauge to be modified
  * @param status The status value that should be modified
  * @param uuid The UUID of the instance. (Usually the localPart)
@@ -91,11 +91,11 @@ export function incrementGuageValue(gauge: Gauge<"status" | "uuid">, status: "of
 
 /**
  * This decrements a prometheus gauge. Used in the Appservice MjolnirManager.
- * 
+ *
  * The ts-ignore is mandatory since we access a private method due to lack of a public one.
- * 
+ *
  * See https://github.com/Gnuxie/Draupnir/pull/70#discussion_r1299188922
- * 
+ *
  * @param gauge The Gauge to be modified
  * @param status The status value that should be modified
  * @param uuid The UUID of the instance. (Usually the localPart)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,7 +82,7 @@ export function setToArray<T>(set: Set<T>): T[] {
  * @param status The status value that should be modified
  * @param uuid The UUID of the instance. (Usually the localPart)
  */
-export function incrementGuageValue(gauge: Gauge<"status" | "uuid">, status: "offline" | "disabled" | "online", uuid: string) {
+export function incrementGaugeValue(gauge: Gauge<"status" | "uuid">, status: "offline" | "disabled" | "online", uuid: string) {
     // @ts-ignore
     if (!gauge._getValue({ status: status, uuid: uuid })) {
         gauge.inc({ status: status, uuid: uuid });
@@ -100,7 +100,7 @@ export function incrementGuageValue(gauge: Gauge<"status" | "uuid">, status: "of
  * @param status The status value that should be modified
  * @param uuid The UUID of the instance. (Usually the localPart)
  */
-export function decrementGuageValue(gauge: Gauge<"status" | "uuid">, status: "offline" | "disabled" | "online", uuid: string) {
+export function decrementGaugeValue(gauge: Gauge<"status" | "uuid">, status: "offline" | "disabled" | "online", uuid: string) {
     // @ts-ignore
     if (gauge._getValue({ status: status, uuid: uuid })) {
         gauge.dec({ status: status, uuid: uuid });


### PR DESCRIPTION
This adds a `/healthz` endpoint to the appservice which allows this to work more nicely in kubernetes.

It also adds some metrics for tracking the provisioning state.

Grafana result:
![image](https://github.com/Gnuxie/Draupnir/assets/1374914/9426c8e6-2c1c-469c-8902-1b9e2b6db529)

Note: The ts-ignore are sadly required since the `_getValue` method is not public :/ I didnt find another solution apart from tracking it maybe elsewhere.