### PR TITLE
D4A: Make Provisioned User get PL for management room at creation of management room. 

### DIFF
--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -132,10 +132,13 @@ export class MjolnirManager {
                 preset: 'private_chat',
                 invite: [requestingUserId],
                 name: `${requestingUserId}'s mjolnir`,
-                power_level_content_override: {users: {
-                    [requestingUserId]: 100,
-                    [await mjIntent.matrixClient.getUserId()]: 101
-                }}
+                power_level_content_override: {
+                    users: {
+                        [requestingUserId]: 100,
+                        // Give the mjolnir a higher PL so that can avoid issues with managing the management room.
+                        [await mjIntent.matrixClient.getUserId()]: 101
+                    }
+                }
             });
 
             const mjolnir = await this.makeInstance(requestingUserId, managementRoomId, mjIntent.matrixClient);

--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -134,7 +134,7 @@ export class MjolnirManager {
                 name: `${requestingUserId}'s mjolnir`,
                 power_level_content_override: {users: {
                     [requestingUserId]: 100,
-                    [await mjIntent.matrixClient.getUserId()]: 101 
+                    [await mjIntent.matrixClient.getUserId()]: 101
                 }}
             });
 

--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -134,7 +134,7 @@ export class MjolnirManager {
                 name: `${requestingUserId}'s mjolnir`,
                 power_level_content_override: {users: {
                     [requestingUserId]: 100,
-                    [await mjIntent.matrixClient.getUserId()]: 100 
+                    [await mjIntent.matrixClient.getUserId()]: 101 
                 }}
             });
 

--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -131,7 +131,11 @@ export class MjolnirManager {
             const managementRoomId = await mjIntent.matrixClient.createRoom({
                 preset: 'private_chat',
                 invite: [requestingUserId],
-                name: `${requestingUserId}'s mjolnir`
+                name: `${requestingUserId}'s mjolnir`,
+                power_level_content_override: {users: {
+                    [requestingUserId]: 100,
+                    [await mjIntent.matrixClient.getUserId()]: 100 
+                }}
             });
 
             const mjolnir = await this.makeInstance(requestingUserId, managementRoomId, mjIntent.matrixClient);


### PR DESCRIPTION
This PR has not gotten properly tested with MX tester due to technical issues on the side of the author that has not been able to be resolved currently with help from our lovely maintainer @Gnuxie 

So this PR is just submitted to allow easier testing and tracking. 

I Catalan Lover agree to contribute these changes to the project under the terms of the Apache 2.0 Licence.

