### PR TITLE
package.json: refer to https clone url

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.84.0",
   "description": "A moderation tool for Matrix",
   "main": "lib/index.js",
-  "repository": "git@github.com:Gnuxie/Draupnir.git",
+  "repository": "https://github.com/Gnuxie/Draupnir.git",
   "author": "Gnuxie",
   "license": "SEE LICENSE IN LICENSE",
   "private": true,


### PR DESCRIPTION
This will work in both `git clone` and web browser without requiring a GitHub account with public key added.