### PR TITLE
Add command that allows to easily set the Displayname of a bot

### DIFF
--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -72,6 +72,7 @@ import "./Rooms";
 import "./Rules";
 import "./WatchUnwatchCommand";
 import "./Help";
+import "./SetDisplayNameCommand";
 
 export const COMMAND_PREFIX = "!mjolnir";
 
@@ -124,7 +125,7 @@ export async function handleCommand(roomId: string, event: { content: { body: st
             const readItems = readCommand(cmd).slice(1); // remove "!mjolnir"
             const stream = new ArgumentStream(readItems);
             const command = commandTable.findAMatchingCommand(stream)
-            ?? findTableCommand("mjolnir", "help");
+                ?? findTableCommand("mjolnir", "help");
             const adaptor = findMatrixInterfaceAdaptor(command);
             const mjolnirContext: MjolnirContext = {
                 mjolnir, roomId, event, client: mjolnir.client, emitter: mjolnir.matrixEmitter,

--- a/src/commands/SetDisplayNameCommand.ts
+++ b/src/commands/SetDisplayNameCommand.ts
@@ -1,8 +1,9 @@
-import { LogLevel, LogService } from "matrix-bot-sdk";
-import { defineInterfaceCommand } from "./interface-manager/InterfaceCommand";
+import { defineInterfaceCommand, findTableCommand } from "./interface-manager/InterfaceCommand";
 import { ParsedKeywords, findPresentationType, parameters } from "./interface-manager/ParameterParsing";
 import { MjolnirContext } from "./CommandHandler";
-import { CommandResult } from "./interface-manager/Validation";
+import { CommandError, CommandResult } from "./interface-manager/Validation";
+import { tickCrossRenderer } from "./interface-manager/MatrixHelpRenderer";
+import { defineMatrixInterfaceAdaptor } from "./interface-manager/MatrixInterfaceAdaptor";
 
 
 defineInterfaceCommand({
@@ -21,13 +22,19 @@ defineInterfaceCommand({
 
 // !draupnir displayname <displayname>
 export async function execSetDisplayNameCommand(this: MjolnirContext, _keywords: ParsedKeywords, displayname: string): Promise<CommandResult<any>> {
+
     try {
         await this.client.setDisplayName(displayname);
     } catch (e) {
         const message = e.message || (e.body ? e.body.error : '<no message>');
-        LogService.error("SetDisplayNameCommand", e);
-        await this.mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, "SetDisplayNameCommand", `Failed to set displayname to ${displayname}: ${message}`);
+        return CommandError.Result(`Failed to set displayname to ${displayname}: ${message}`)
     }
+
 
     return CommandResult.Ok(undefined);
 }
+
+defineMatrixInterfaceAdaptor({
+    interfaceCommand: findTableCommand("mjolnir", "displayname"),
+    renderer: tickCrossRenderer
+})

--- a/src/commands/SetDisplayNameCommand.ts
+++ b/src/commands/SetDisplayNameCommand.ts
@@ -21,16 +21,12 @@ defineInterfaceCommand({
 
 // !draupnir displayname <displayname>
 export async function execSetDisplayNameCommand(this: MjolnirContext, _keywords: ParsedKeywords, displayname: string): Promise<CommandResult<any>> {
-    let targetRooms = this.mjolnir.protectedRoomsTracker.getProtectedRooms();
-
-    for (const targetRoomId of targetRooms) {
-        try {
-            await this.client.setDisplayName(displayname);
-        } catch (e) {
-            const message = e.message || (e.body ? e.body.error : '<no message>');
-            LogService.error("SetDisplayNameCommand", e);
-            await this.mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, "SetDisplayNameCommand", `Failed to set displayname to ${displayname} in ${targetRoomId}: ${message}`, targetRoomId);
-        }
+    try {
+        await this.client.setDisplayName(displayname);
+    } catch (e) {
+        const message = e.message || (e.body ? e.body.error : '<no message>');
+        LogService.error("SetDisplayNameCommand", e);
+        await this.mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, "SetDisplayNameCommand", `Failed to set displayname to ${displayname}: ${message}`);
     }
 
     return CommandResult.Ok(undefined);

--- a/src/commands/SetDisplayNameCommand.ts
+++ b/src/commands/SetDisplayNameCommand.ts
@@ -1,0 +1,37 @@
+import { LogLevel, LogService } from "matrix-bot-sdk";
+import { defineInterfaceCommand } from "./interface-manager/InterfaceCommand";
+import { ParsedKeywords, findPresentationType, parameters } from "./interface-manager/ParameterParsing";
+import { MjolnirContext } from "./CommandHandler";
+import { CommandResult } from "./interface-manager/Validation";
+
+
+defineInterfaceCommand({
+    table: "mjolnir",
+    designator: ["displayname"],
+    summary: "Sets the displayname of the draupnir instance to the specified value in all rooms.",
+    parameters: parameters([
+        {
+            name: 'displayname',
+            acceptor: findPresentationType("string"),
+            description: 'The displayname to set.'
+        }
+    ]),
+    command: execSetDisplayNameCommand
+})
+
+// !draupnir displayname <displayname>
+export async function execSetDisplayNameCommand(this: MjolnirContext, _keywords: ParsedKeywords, displayname: string): Promise<CommandResult<any>> {
+    let targetRooms = this.mjolnir.protectedRoomsTracker.getProtectedRooms();
+
+    for (const targetRoomId of targetRooms) {
+        try {
+            await this.client.setDisplayName(displayname);
+        } catch (e) {
+            const message = e.message || (e.body ? e.body.error : '<no message>');
+            LogService.error("SetDisplayNameCommand", e);
+            await this.mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, "SetDisplayNameCommand", `Failed to set displayname to ${displayname} in ${targetRoomId}: ${message}`, targetRoomId);
+        }
+    }
+
+    return CommandResult.Ok(undefined);
+}

--- a/src/commands/SetDisplayNameCommand.ts
+++ b/src/commands/SetDisplayNameCommand.ts
@@ -1,5 +1,5 @@
 import { defineInterfaceCommand, findTableCommand } from "./interface-manager/InterfaceCommand";
-import { ParsedKeywords, findPresentationType, parameters } from "./interface-manager/ParameterParsing";
+import { ParsedKeywords, RestDescription, findPresentationType, parameters } from "./interface-manager/ParameterParsing";
 import { MjolnirContext } from "./CommandHandler";
 import { CommandError, CommandResult } from "./interface-manager/Validation";
 import { tickCrossRenderer } from "./interface-manager/MatrixHelpRenderer";
@@ -10,26 +10,25 @@ defineInterfaceCommand({
     table: "mjolnir",
     designator: ["displayname"],
     summary: "Sets the displayname of the draupnir instance to the specified value in all rooms.",
-    parameters: parameters([
-        {
-            name: 'displayname',
-            acceptor: findPresentationType("string"),
-            description: 'The displayname to set.'
-        }
-    ]),
+    parameters: parameters(
+        [],
+        new RestDescription<MjolnirContext>(
+            "displayname",
+            findPresentationType("string"),
+        ),
+    ),
     command: execSetDisplayNameCommand
 })
 
 // !draupnir displayname <displayname>
-export async function execSetDisplayNameCommand(this: MjolnirContext, _keywords: ParsedKeywords, displayname: string): Promise<CommandResult<any>> {
-
+export async function execSetDisplayNameCommand(this: MjolnirContext, _keywords: ParsedKeywords, ...displaynameParts: string[]): Promise<CommandResult<any>> {
+    const displayname = displaynameParts.join(' ');
     try {
         await this.client.setDisplayName(displayname);
     } catch (e) {
         const message = e.message || (e.body ? e.body.error : '<no message>');
         return CommandError.Result(`Failed to set displayname to ${displayname}: ${message}`)
     }
-
 
     return CommandResult.Ok(undefined);
 }


### PR DESCRIPTION
This adds the `displayname` command which just sets the displayname of the user.