### PR TITLE
Unban propagation

### DIFF
--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -48,7 +48,7 @@ import { BaseFunction, CommandTable, defineCommandTable, findCommandTable, findT
 import { findMatrixInterfaceAdaptor, MatrixContext } from "./interface-manager/MatrixInterfaceAdaptor";
 import { ArgumentStream } from "./interface-manager/ParameterParsing";
 import { CommandResult } from "./interface-manager/Validation";
-import { CommandException } from "./interface-manager/CommandException";
+import { CommandException, CommandExceptionKind } from "./interface-manager/CommandException";
 import { tickCrossRenderer } from "./interface-manager/MatrixHelpRenderer";
 import "./interface-manager/MatrixPresentations";
 
@@ -133,7 +133,7 @@ export async function handleCommand(roomId: string, event: { content: { body: st
             try {
                 return await adaptor.invoke(mjolnirContext, mjolnirContext, ...stream.rest());
             } catch (e) {
-                const commandError = new CommandException(e, 'Unknown Unexpected Error');
+                const commandError = new CommandException(CommandExceptionKind.Unknown, e, 'Unknown Unexpected Error');
                 await tickCrossRenderer.call(mjolnirContext, mjolnir.client, roomId, event, CommandResult.Err(commandError));
             }
         }

--- a/src/commands/Rooms.tsx
+++ b/src/commands/Rooms.tsx
@@ -30,7 +30,7 @@ import { findPresentationType, parameters } from "./interface-manager/ParameterP
 import { MjolnirContext } from "./CommandHandler";
 import { MatrixRoomID, MatrixRoomReference } from "./interface-manager/MatrixRoomReference";
 import { CommandResult } from "./interface-manager/Validation";
-import { CommandException } from "./interface-manager/CommandException";
+import { CommandException, CommandExceptionKind } from "./interface-manager/CommandException";
 import { defineMatrixInterfaceAdaptor } from "./interface-manager/MatrixInterfaceAdaptor";
 import { tickCrossRenderer } from "./interface-manager/MatrixHelpRenderer";
 import { DocumentNode } from "./interface-manager/DeadDocument";
@@ -92,7 +92,7 @@ defineInterfaceCommand({
                 return CommandException.Result<MatrixRoomID>(
                     `The homeserver that Draupnir is hosted on cannot join this room using the room reference provided.\
                     Try an alias or the "share room" button in your client to obtain a valid reference to the room.`,
-                    { exception: e }
+                    { exception: e, exceptionKind: CommandExceptionKind.Unknown }
                 );
             }
         })();
@@ -121,7 +121,10 @@ defineInterfaceCommand({
         try {
             await this.mjolnir.client.leaveRoom(roomID.toRoomIdOrAlias());
         } catch (exception) {
-            return CommandException.Result(`Failed to leave ${roomRef.toPermalink()} - the room is no longer being protected, but the bot could not leave.`, { exception });
+            return CommandException.Result(
+                `Failed to leave ${roomRef.toPermalink()} - the room is no longer being protected, but the bot could not leave.`,
+                { exceptionKind: CommandExceptionKind.Unknown, exception }
+            );
         }
         return CommandResult.Ok(undefined);
     },

--- a/src/commands/Rules.tsx
+++ b/src/commands/Rules.tsx
@@ -60,7 +60,7 @@ async function renderListMatches(
     )
 }
 
-function renderListRules(list: ListMatches) {
+export function renderListRules(list: ListMatches) {
     const renderRuleSummary = (rule: ListRule, entityDescription: string) => {
         return <li>
             {entityDescription} (<code>{rule.recommendation}</code>): <code>{rule.entity}</code> ({rule.reason})

--- a/src/commands/interface-manager/CommandException.ts
+++ b/src/commands/interface-manager/CommandException.ts
@@ -5,6 +5,22 @@
 
 import { randomUUID } from "crypto";
 import { CommandError, CommandResult } from "./Validation";
+import { LogService } from "matrix-bot-sdk";
+
+export enum CommandExceptionKind {
+    /**
+     * This class is for exceptions that need to be reported to the user,
+     * but are mostly irrelevant to the developers because the behaviour is well
+     * understood and expected. These exceptions will never be logged to the error
+     * level.
+     */
+    Known = 'Known',
+    /**
+     * This class is to be used for reporting unexpected or unknown exceptions
+     * that the developers need to know about.
+     */
+    Unknown = 'Unknown',
+}
 
 // FIXME: I wonder if we could allow message to be JSX?
 //        Then room references could be put into the DM and actually mean something.
@@ -12,12 +28,22 @@ export class CommandException extends CommandError {
     public readonly uuid = randomUUID();
 
     constructor(
+        public readonly exceptionKind: CommandExceptionKind,
         public readonly exception: Error|unknown,
         message: string) {
         super(message)
     }
 
-    public static Result<Ok>(message: string, options: { exception: Error }): CommandResult<Ok, CommandException> {
-        return CommandResult.Err(new CommandException(options.exception, message));
+    public static Result<Ok>(message: string, options: { exception: Error, exceptionKind: CommandExceptionKind }): CommandResult<Ok, CommandException> {
+        return CommandResult.Err(new CommandException(options.exceptionKind, options.exception, message));
+    }
+
+    protected log(): void {
+        const logArguments: Parameters<typeof LogService['info']> = ["CommandException", this.exceptionKind, this.uuid, this.message, this.exception];
+        if (this.exceptionKind === CommandExceptionKind.Known) {
+            LogService.info(...logArguments);
+        } else {
+            LogService.error(...logArguments);
+        }
     }
 }

--- a/src/commands/interface-manager/Validation.ts
+++ b/src/commands/interface-manager/Validation.ts
@@ -24,6 +24,7 @@ limitations under the License.
  * However, this file is modified and the modifications in this file
  * are NOT distributed, contributed, committed, or licensed under the Apache License.
  */
+import { LogService } from "matrix-bot-sdk";
 
 type ValidationMatchExpression<Ok, Err> = { ok?: (ok: Ok) => any, err?: (err: Err) => any};
 
@@ -89,7 +90,7 @@ export class CommandError {
     public constructor(
         public readonly message: string,
     ) {
-
+        this.log();
     }
 
     /**
@@ -100,5 +101,9 @@ export class CommandError {
      */
     public static Result<Ok>(message: string, _options = {}): CommandResult<Ok> {
         return CommandResult.Err(new CommandError(message));
+    }
+
+    protected log(): void {
+        LogService.info("CommandError", this.message);
     }
 }

--- a/src/protections/BanPropagation.tsx
+++ b/src/protections/BanPropagation.tsx
@@ -23,6 +23,9 @@ limitations under the License.
  *
  * However, this file is modified and the modifications in this file
  * are NOT distributed, contributed, committed, or licensed under the Apache License.
+ *
+ * In addition to the above, I want to add that this protection was inspired by
+ * a Mjolnir PR that was originally created by Gergő Fándly https://github.com/matrix-org/mjolnir/pull/223
  */
 
 import { Protection } from "./Protection";
@@ -31,17 +34,19 @@ import { LogService } from "matrix-bot-sdk";
 import { JSXFactory } from "../commands/interface-manager/JSXFactory";
 import { renderMatrixAndSend } from "../commands/interface-manager/DeadDocumentMatrix";
 import { renderMentionPill } from "../commands/interface-manager/MatrixHelpRenderer";
-import { RULE_USER } from "../models/ListRule";
+import { RULE_USER, ListRule } from "../models/ListRule";
 import { UserID } from "matrix-bot-sdk";
-import { ReactionListener } from "../commands/interface-manager/MatrixReactionHandler";
-import { PolicyListManager } from "../models/PolicyListManager";
 import { MatrixRoomReference } from "../commands/interface-manager/MatrixRoomReference";
 import { findPolicyListFromRoomReference } from "../commands/Ban";
+import PolicyList from "../models/PolicyList";
+import { renderListRules } from "../commands/Rules";
+import { ERROR_KIND_FATAL, ERROR_KIND_PERMISSION, printActionResult, RoomUpdateError } from "../models/RoomUpdateError";
 
-const PROPAGATION_PROMPT_LISTENER = 'ge.applied-langua.ge.draupnir.ban_propagation';
+const BAN_PROPAGATION_PROMPT_LISTENER = 'ge.applied-langua.ge.draupnir.ban_propagation';
+const UNBAN_PROPAGATION_PROMPT_LISTENER = 'ge.applied-langua.ge.draupnir.unban_propagation';
 
-function makePolicyListShortcodeReferenceMap(lists: PolicyListManager): Map<string, string> {
-    return lists.lists.reduce((map, list, index) => (map.set(`${index + 1}.`, list.roomRef), map), new Map())
+function makePolicyListShortcodeReferenceMap(lists: PolicyList[]): Map<string, string> {
+    return lists.reduce((map, list, index) => (map.set(`${index + 1}.`, list.roomRef), map), new Map())
 }
 
 // would be nice to be able to use presentation types here idk.
@@ -62,7 +67,7 @@ async function promptBanPropagation(
     event: any,
     roomId: string
 ): Promise</*event id*/string> {
-    const reactionMap = makePolicyListShortcodeReferenceMap(mjolnir.policyListManager);
+    const reactionMap = makePolicyListShortcodeReferenceMap(mjolnir.policyListManager.lists);
     const promptEventId = (await renderMatrixAndSend(
         <root>The user {renderMentionPill(event["state_key"], event["content"]?.["displayname"] ?? event["state_key"])} was banned
                 in <a href={`https://matrix.to/#/${roomId}`}>{roomId}</a> by {new UserID(event["sender"])} for <code>{event["content"]?.["reason"] ?? '<no reason supplied>'}</code>.<br/>
@@ -75,7 +80,7 @@ async function promptBanPropagation(
         undefined,
         mjolnir.client,
         mjolnir.reactionHandler.createAnnotation(
-            PROPAGATION_PROMPT_LISTENER,
+            BAN_PROPAGATION_PROMPT_LISTENER,
             reactionMap,
             {
                 target: event["state_key"],
@@ -85,6 +90,118 @@ async function promptBanPropagation(
     )).at(0) as string;
     await mjolnir.reactionHandler.addReactionsToEvent(mjolnir.client, mjolnir.managementRoomId, promptEventId, reactionMap);
     return promptEventId;
+}
+
+async function promptUnbanPropagation(
+    mjolnir: Mjolnir,
+    event: any,
+    roomId: string,
+    rulesMatchingUser: Map<PolicyList, ListRule[]>
+): Promise</*event id*/string> {
+    const reactionMap = new Map<string, string>(Object.entries({ 'unban from all': 'unban from all'}));
+    // shouldn't we warn them that the unban will be futile?
+    const promptEventId = (await renderMatrixAndSend(
+        <root>
+            The user {renderMentionPill(event["state_key"], event["content"]?.["displayname"] ?? event["state_key"])} was unbanned
+            from the room <a href={`https://matrix.to/#/${roomId}`}>{roomId}</a> by {new UserID(event["sender"])} for <code>{event["content"]?.["reason"] ?? '<no reason supplied>'}</code>.<br/>
+            However there are rules in Draupnir's watched lists matching this user:
+            <ul>
+            {
+            [...rulesMatchingUser.entries()]
+                .map(([list, rules]) => <li>{renderListRules({
+                    shortcode: list.listShortcode,
+                    roomRef: list.roomRef,
+                    roomId: list.roomId,
+                    matches: rules
+                })}</li>)
+            }
+            </ul>
+            Would you like to remove these rules and unban the user from all protected rooms?
+        </root>,
+        mjolnir.managementRoomId,
+        undefined,
+        mjolnir.client,
+        mjolnir.reactionHandler.createAnnotation(
+            UNBAN_PROPAGATION_PROMPT_LISTENER,
+            reactionMap,
+            {
+                target: event["state_key"],
+                reason: event["content"]?.["reason"],
+            }
+        )
+    )).at(0) as string;
+    await mjolnir.reactionHandler.addReactionsToEvent(mjolnir.client, mjolnir.managementRoomId, promptEventId, reactionMap);
+    return promptEventId;
+}
+
+interface ListenerContext {
+    mjolnir: Mjolnir,
+}
+
+async function banReactionListener(this: ListenerContext, key: string, item: unknown, context: BanPropagationMessageContext) {
+    try {
+        if (typeof item === 'string') {
+            const listRef = MatrixRoomReference.fromPermalink(item);
+            const listResult = await findPolicyListFromRoomReference(this.mjolnir, listRef);
+            if (listResult.isOk()) {
+                return await listResult.ok.banEntity(RULE_USER, context.target, context.reason);
+            } else {
+                LogService.warn("BanPropagation", "Timed out waiting for a response to a room level ban", listResult.err);
+                return;
+            }
+        } else {
+            throw new TypeError("The ban prompt event's reaction map is malformed.")
+        }
+    } catch (e) {
+        LogService.error('BanPropagation', "Encountered an error while prompting the user for instructions to propagate a room level ban", e);
+    }
+}
+
+async function unbanFromAllLists(mjolnir: Mjolnir, user: string): Promise<RoomUpdateError[]> {
+    const errors: RoomUpdateError[] = [];
+    for (const list of mjolnir.policyListManager.lists) {
+        try {
+            await list.unbanEntity(RULE_USER, user);
+        } catch (e) {
+            LogService.info('BanPropagation', `Could not unban ${user} from ${list.roomRef}`, e);
+            const message = e.message || (e.body ? e.body.error : '<no message>');
+            errors.push({
+                roomId: list.roomId,
+                errorMessage: message,
+                errorKind: message.includes("You don't have permission") ? ERROR_KIND_PERMISSION : ERROR_KIND_FATAL
+            })
+        }
+    }
+    return errors;
+}
+
+async function unbanUserReactionListener(this: ListenerContext, _key: string, item: unknown, context: BanPropagationMessageContext): Promise<void> {
+    try {
+        if (item === 'unban from all') {
+            const listErrors = await unbanFromAllLists(this.mjolnir, context.target);
+            if (listErrors.length > 0) {
+                await printActionResult(
+                    this.mjolnir.client,
+                    this.mjolnir.managementRoomId,
+                    listErrors,
+                    { title: `There were errors unbanning ${context.target} from all lists.`}
+                );
+            } else {
+                const unbanErrors = await this.mjolnir.protectedRoomsTracker.unbanUser(context.target);
+                await printActionResult(
+                    this.mjolnir.client,
+                    this.mjolnir.managementRoomId,
+                    unbanErrors,
+                    {
+                        title: `There were errors unbanning ${context.target} from protected rooms.`,
+                        noErrorsText: `Done unbanning ${context.target} from protected rooms - no errors.`
+                    }
+                );
+            }
+        }
+    } catch (e) {
+        LogService.error(`BanPropagationProtection`, "Unexpected error unbanning a user", e);
+    }
 }
 
 export class BanPropagation extends Protection {
@@ -101,39 +218,35 @@ export class BanPropagation extends Protection {
     }
 
     public async registerProtection(mjolnir: Mjolnir): Promise<void> {
-        const listener: ReactionListener = async (key, item, context: BanPropagationMessageContext) => {
-            try {
-                if (typeof item === 'string') {
-                    const listRef = MatrixRoomReference.fromPermalink(item);
-                    const listResult = await findPolicyListFromRoomReference(mjolnir, listRef);
-                    if (listResult.isOk()) {
-                        return listResult.ok.banEntity(RULE_USER, context.target, context.reason);
-                    } else {
-                        LogService.warn("BanPropagation", "Timed out waiting for a response to a room level ban", listResult.err);
-                        return;
-                    }
-                } else {
-                    throw new TypeError("The ban prompt event's reaction map is malformed.")
-                }
-            } catch (e) {
-                LogService.error('BanPropagation', "Encountered an error while prompting the user for instructions to propagate a room level ban", e);
-            }
-        };
-        mjolnir.reactionHandler.on(PROPAGATION_PROMPT_LISTENER, listener);
+        mjolnir.reactionHandler.on(BAN_PROPAGATION_PROMPT_LISTENER, banReactionListener.bind({ mjolnir }));
+        mjolnir.reactionHandler.on(UNBAN_PROPAGATION_PROMPT_LISTENER, unbanUserReactionListener.bind({ mjolnir }));
     }
 
     public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
-        if (event['type'] !== 'm.room.member' || event['content']?.['membership'] !== 'ban') {
+        if (event['type'] !== 'm.room.member'
+            || !(event['content']?.['membership'] === 'ban' || event['content']?.['membership'] === 'leave')) {
             return;
         }
-        if (mjolnir.policyListManager.lists.map(
-                list => list.rulesMatchingEntity(event['state_key'], RULE_USER)
-            ).some(rules => rules.length > 0)
-        ) {
-            return; // The user is already banned.
+        const rulesMatchingUser = mjolnir.policyListManager.lists.reduce(
+            (listMap, list) => {
+                const rules = list.rulesMatchingEntity(event['state_key'], RULE_USER);
+                if (rules.length > 0) {
+                    listMap.set(list, rules)
+                };
+                return listMap
+            }, new Map<PolicyList, ListRule[]>()
+        );
+        const userMembership = event['content']?.['membership'];
+        if (userMembership === 'ban') {
+            if (rulesMatchingUser.size > 0) {
+                return; // The user is already banned.
+            }
+            // do not await, we don't want to block the protection manager
+            promptBanPropagation(mjolnir, event, roomId)
+        } else if (userMembership === 'leave' && rulesMatchingUser.size > 0) {
+            // Then this is a banned user being unbanned.
+            // do not await, we don't want to block the protection manager
+            promptUnbanPropagation(mjolnir, event, roomId, rulesMatchingUser);
         }
-        // do not await, we don't want to block the protection manager
-        promptBanPropagation(mjolnir, event, roomId)
-
     }
 }

--- a/src/protections/ProtectionManager.ts
+++ b/src/protections/ProtectionManager.ts
@@ -39,11 +39,11 @@ import { LogLevel, LogService } from "matrix-bot-sdk";
 import { ProtectionSettingValidationError } from "./ProtectionSettings";
 import { Consequence } from "./consequence";
 import { htmlEscape } from "../utils";
-import { ERROR_KIND_FATAL, ERROR_KIND_PERMISSION } from "../models/RoomUpdateError";
-import { RoomUpdateError } from "../models/RoomUpdateError";
+import { IRoomUpdateError, PermissionError, RoomUpdateException } from "../models/RoomUpdateError";
 import { BanPropagation } from "./BanPropagation";
 import { MatrixDataManager, RawSchemedData, SchemaMigration, SCHEMA_VERSION_KEY } from "../models/MatrixDataManager";
 import { Permalinks } from "../commands/interface-manager/Permalinks";
+import { CommandExceptionKind } from "../commands/interface-manager/CommandException";
 
 const PROTECTIONS: Protection[] = [
     new FirstMessageIsImage(),
@@ -384,8 +384,8 @@ export class ProtectionManager {
         return new Set(this.enabledProtections.map((p) => p.requiredStatePermissions).flat())
     }
 
-    public async verifyPermissionsIn(roomId: string): Promise<RoomUpdateError[]> {
-        const errors: RoomUpdateError[] = [];
+    public async verifyPermissionsIn(roomId: string): Promise<IRoomUpdateError[]> {
+        const errors: IRoomUpdateError[] = [];
         const additionalPermissions = this.requiredProtectionPermissions();
 
         try {
@@ -413,35 +413,21 @@ export class ProtectionManager {
             const userLevel = plDefault(users[ownUserId], usersDefault);
             const aclLevel = plDefault(events["m.room.server_acl"], stateDefault);
 
-            // Wants: ban, kick, redact, m.room.server_acl
+            const addErrorToReport = (message: string) => {
+                errors.push(new PermissionError(roomId, message))
+            }
 
             if (userLevel < ban) {
-                errors.push({
-                    roomId,
-                    errorMessage: `Missing power level for bans: ${userLevel} < ${ban}`,
-                    errorKind: ERROR_KIND_PERMISSION,
-                });
+                addErrorToReport(`Missing power level for bans: ${userLevel} < ${ban}`);
             }
             if (userLevel < kick) {
-                errors.push({
-                    roomId,
-                    errorMessage: `Missing power level for kicks: ${userLevel} < ${kick}`,
-                    errorKind: ERROR_KIND_PERMISSION,
-                });
+                addErrorToReport(`Missing power level for kicks: ${userLevel} < ${kick}`);
             }
             if (userLevel < redact) {
-                errors.push({
-                    roomId,
-                    errorMessage: `Missing power level for redactions: ${userLevel} < ${redact}`,
-                    errorKind: ERROR_KIND_PERMISSION,
-                });
+                addErrorToReport(`Missing power level for redactions: ${userLevel} < ${redact}`);
             }
             if (!this.mjolnir.config.disableServerACL && userLevel < aclLevel) {
-                errors.push({
-                    roomId,
-                    errorMessage: `Missing power level for server ACLs: ${userLevel} < ${aclLevel}`,
-                    errorKind: ERROR_KIND_PERMISSION,
-                });
+                addErrorToReport(`Missing power level for server ACLs: ${userLevel} < ${aclLevel}`);
             }
 
             // Wants: Additional permissions
@@ -450,24 +436,15 @@ export class ProtectionManager {
                 const permLevel = plDefault(events[additionalPermission], stateDefault);
 
                 if (userLevel < permLevel) {
-                    errors.push({
-                        roomId,
-                        errorMessage: `Missing power level for "${additionalPermission}" state events: ${userLevel} < ${permLevel}`,
-                        errorKind: ERROR_KIND_PERMISSION,
-                    });
+                    addErrorToReport(`Missing power level for "${additionalPermission}" state events: ${userLevel} < ${permLevel}`);
                 }
             }
 
             // Otherwise OK
         } catch (e) {
-            LogService.error("Mjolnir", e);
-            errors.push({
-                roomId,
-                errorMessage: e.message || (e.body ? e.body.error : '<no message>'),
-                errorKind: ERROR_KIND_FATAL,
-            });
+            const message = `Unexpected error when attempting to verify the permissions in ${roomId}`;
+            errors.push(new RoomUpdateException(roomId, CommandExceptionKind.Unknown, e, message));
         }
-
         return errors;
     }
 

--- a/src/queues/EventRedactionQueue.ts
+++ b/src/queues/EventRedactionQueue.ts
@@ -25,11 +25,11 @@ limitations under the License.
  * are NOT distributed, contributed, committed, or licensed under the Apache License.
  */
 import { LogLevel, MatrixClient } from "matrix-bot-sdk"
-import { ERROR_KIND_FATAL } from "../models/RoomUpdateError";
-import { RoomUpdateError } from "../models/RoomUpdateError";
+import { IRoomUpdateError, RoomUpdateException } from "../models/RoomUpdateError";
 import { redactUserMessagesIn } from "../utils";
 import ManagementRoomOutput from "../ManagementRoomOutput";
 import { MatrixSendClient } from "../MatrixEmitter";
+import { CommandExceptionKind } from "../commands/interface-manager/CommandException";
 
 export interface QueuedRedaction {
     /** The room which the redaction will take place in. */
@@ -119,25 +119,21 @@ export class EventRedactionQueue {
      * @param limitToRoomId If the roomId is provided, only redactions for that room will be processed.
      * @returns A description of any errors encountered by each QueuedRedaction that was processed.
      */
-    public async process(client: MatrixSendClient, managementRoom: ManagementRoomOutput, limitToRoomId?: string): Promise<RoomUpdateError[]> {
-        const errors: RoomUpdateError[] = [];
+    public async process(client: MatrixSendClient, managementRoom: ManagementRoomOutput, limitToRoomId?: string): Promise<IRoomUpdateError[]> {
+        const errors: IRoomUpdateError[] = [];
         const redact = async (currentBatch: QueuedRedaction[]) => {
             for (const redaction of currentBatch) {
                 try {
                     await redaction.redact(client, managementRoom);
                 } catch (e) {
-                    let roomError: RoomUpdateError;
-                    if (e.roomId && e.errorMessage && e.errorKind) {
-                        roomError = e;
-                    } else {
-                        const message = e.message || (e.body ? e.body.error : '<no message>');
-                        roomError = {
-                            roomId: redaction.roomId,
-                            errorMessage: message,
-                            errorKind: ERROR_KIND_FATAL,
-                        };
-                    }
-                    errors.push(roomError);
+                    const message = e.message || (e.body ? e.body.error : '<no message>');
+                    const error = new RoomUpdateException(
+                        redaction.roomId,
+                        CommandExceptionKind.Unknown,
+                        e,
+                        message
+                    );
+                    errors.push(error);
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/Gnuxie/Draupnir/issues/83
Fixes https://github.com/Gnuxie/Draupnir/issues/84
Related #92 

Extends the ban propagation to offer to unban a user from all protected rooms when an unban is detected in a protected room.

![image](https://github.com/Gnuxie/Draupnir/assets/50846879/e6dd51c9-693f-4ea3-8f0a-4bf6702fccd0)

Thoughts:

- [x] The pattern for using `printActionResult` is common but lacks context about what caused `RoomUpdateErrors`, including whether they are expected or unexpected. We also don't utilise `CommandError/Result` which would give the id for admins to track the error if it was unexpected.
- [x] It's not clear which situations we should use the log level `ERROR` or `INFO` depending on what caused unban to fail (similar to CommandError, which has a distinction between reporting known errors and unexpected errors)
-  Collecting RoomUpdateErrors is a common pattern.
- There's probably a lot of duplicated effort between the ban and unban listeners